### PR TITLE
add support for mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,24 +114,6 @@ plans to add Leiningen support.
 
 [Documentation can be found here](https://kit-clj.github.io)
 
-## Development setup
-
-Minimum Clojure CLI version: 1.10.3.933
-
-To install the libraries locally
-
-`clojure -T:build install-libs`
-
-To install a single library locally
-
-`clojure -T:build install-lib :artifact-id :lein-template`
-
-To push a single library to Clojars
-
-`clojure -T:build install-lib :artifact-id <artifact-id> :publish true`
-
-eg: `clojure -T:build install-lib :artifact-id :kit-generator :publish true`
-
 ## Inspiration and thanks to
 
 - [integrant](https://github.com/weavejester/integrant) as

--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ To install a single library locally
 
 To push a single library to Clojars
 
-`clojure -T:build install-lib :artifact-id :lein-template :publish true`
+`clojure -T:build install-lib :artifact-id <artifact-id> :publish true`
+
+eg: `clojure -T:build install-lib :artifact-id :kit-generator :publish true`
 
 ## Inspiration and thanks to
 

--- a/README.md
+++ b/README.md
@@ -31,17 +31,18 @@ the system configuration EDN file.
 |---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
 | io.github.kit-clj/kit-core      | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-core.svg)](https://clojars.org/io.github.kit-clj/kit-core)           |
 | io.github.kit-clj/kit-hato      | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-hato.svg)](https://clojars.org/io.github.kit-clj/kit-hato)           |
-| io.github.kit-clj/kit-metrics   | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-metrics.svg)](https://clojars.org/io.github.kit-clj/kit-metrics)     |
-| io.github.kit-clj/kit-nrepl     | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-nrepl.svg)](https://clojars.org/io.github.kit-clj/kit-nrepl)         |
-| io.github.kit-clj/kit-quartz    | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-quartz.svg)](https://clojars.org/io.github.kit-clj/kit-quartz)       |
-| io.github.kit-clj/kit-redis     | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-redis.svg)](https://clojars.org/io.github.kit-clj/kit-redis)         |
+| io.github.kit-clj/kit-http-kit  | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-http-kit.svg)](https://clojars.org/io.github.kit-clj/kit-http-kit)       |
+| io.github.kit-clj/kit-metrics   | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-metrics.svg)](https://clojars.org/io.github.kit-clj/kit-metrics)        |
+| io.github.kit-clj/kit-nrepl     | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-nrepl.svg)](https://clojars.org/io.github.kit-clj/kit-nrepl)          |
+| io.github.kit-clj/kit-quartz    | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-quartz.svg)](https://clojars.org/io.github.kit-clj/kit-quartz)         |
+| io.github.kit-clj/kit-redis     | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-redis.svg)](https://clojars.org/io.github.kit-clj/kit-redis)          |
 | io.github.kit-clj/kit-repl      | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-repl.svg)](https://clojars.org/io.github.kit-clj/kit-repl)           |
-| io.github.kit-clj/kit-selmer    | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-selmer.svg)](https://clojars.org/io.github.kit-clj/kit-selmer)       |
-| io.github.kit-clj/kit-sql       | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-sql.svg)](https://clojars.org/io.github.kit-clj/kit-sql)             |
-| io.github.kit-clj/kit-postgres  | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-postgres.svg)](https://clojars.org/io.github.kit-clj/kit-postgres)   |
+| io.github.kit-clj/kit-selmer    | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-selmer.svg)](https://clojars.org/io.github.kit-clj/kit-selmer)         |
+| io.github.kit-clj/kit-sql       | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-sql.svg)](https://clojars.org/io.github.kit-clj/kit-sql)            |
+| io.github.kit-clj/kit-postgres  | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-postgres.svg)](https://clojars.org/io.github.kit-clj/kit-postgres)       |
 | io.github.kit-clj/kit-xtdb      | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-xtdb.svg)](https://clojars.org/io.github.kit-clj/kit-xtdb)           |
-| io.github.kit-clj/kit-generator | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-generator.svg)](https://clojars.org/io.github.kit-clj/kit-generator) |
-| io.github.kit-clj/lein-template | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/lein-template.svg)](https://clojars.org/io.github.kit-clj/lein-template) |
+| io.github.kit-clj/kit-generator | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/kit-generator.svg)](https://clojars.org/io.github.kit-clj/kit-generator)      |
+| io.github.kit-clj/lein-template | [![Clojars Project](https://img.shields.io/clojars/v/io.github.kit-clj/lein-template.svg)](https://clojars.org/io.github.kit-clj/lein-template)      |
 
 ### Profiles
 

--- a/libs/lein-template/resources/leiningen/new/kit/deps.edn
+++ b/libs/lein-template/resources/leiningen/new/kit/deps.edn
@@ -51,7 +51,7 @@
            :nrepl {:extra-deps {nrepl/nrepl {:mvn/version "0.9.0"}}
                    :main-opts  ["-m" "nrepl.cmdline" "-i"]}
            :cider {:extra-deps {nrepl/nrepl       {:mvn/version "0.9.0"}
-                                cider/cider-nrepl {:mvn/version "0.22.4"}}
+                                cider/cider-nrepl {:mvn/version "0.28.0"}}
                    :main-opts  ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]" "-i"]}
 
            :test {:extra-deps  {criterium/criterium                  {:mvn/version "0.4.6"}

--- a/versions.edn
+++ b/versions.edn
@@ -1,7 +1,7 @@
 {"kit-core"      "1.0.0"
  "kit-http-kit"  "1.0.0"
  "kit-xtdb"      "1.0.0"
- "kit-generator" "0.1.0"
+ "kit-generator" "0.1.1"
  "kit-hato"      "1.0.0"
  "kit-nrepl"     "1.0.0"
  "kit-metrics"   "1.0.1"


### PR DESCRIPTION
adds support for general sql support. including

- `kit-sql-general` - General sql layer, just contains connection pooling (via [hikari-cp](https://github.com/tomekw/hikari-cp)) and jdbc wrapper (via [next.jdbc](https://github.com/seancorfield/next-jdbc)).
- `kit-mysql` - JDBC Driver working with MySQL8+

daily sql stack here: hikaricp for connection pooling, next-jdbc for DB sql talking, honeysql for sql manipulating.
